### PR TITLE
字段支持在列表页面隐藏

### DIFF
--- a/template/types/info.go
+++ b/template/types/info.go
@@ -145,12 +145,13 @@ type Field struct {
 
 	Joins Joins
 
-	Width      int
-	Sortable   bool
-	EditAble   bool
-	Fixed      bool
-	Filterable bool
-	Hide       bool
+	Width       int
+	Sortable    bool
+	EditAble    bool
+	Fixed       bool
+	Filterable  bool
+	Hide        bool
+	HideForList bool
 
 	EditType    table.Type
 	EditOptions FieldOptions
@@ -326,6 +327,9 @@ func (f FieldList) GetTheadAndFilterForm(info TableInfo, params parameter.Parame
 		}
 
 		if field.Hide {
+			continue
+		}
+		if field.HideForList {
 			continue
 		}
 		thead = append(thead, TheadItem{
@@ -1310,6 +1314,11 @@ func (i *InfoPanel) FieldFilterOnChooseDisable(value string, field ...string) *I
 
 func (i *InfoPanel) FieldHide() *InfoPanel {
 	i.FieldList[i.curFieldListIndex].Hide = true
+	return i
+}
+
+func (i *InfoPanel) FieldHideForList() *InfoPanel {
+	i.FieldList[i.curFieldListIndex].HideForList = true
 	return i
 }
 


### PR DESCRIPTION
在某些场景下，有些字段不需要在列表页展示，只需要在详情页面展示。