### PR TITLE
Fix parameter_pk crash when __pk is missing

### DIFF
--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -153,7 +153,7 @@ func (param Parameters) WithPKs(id ...string) Parameters {
 func (param Parameters) PKs() []string {
 	pk := param.GetFieldValue(PrimaryKey)
 	if pk == "" {
-		return []string{}
+		return make([]string, 1)
 	}
 	return strings.Split(param.GetFieldValue(PrimaryKey), ",")
 }


### PR DESCRIPTION
When pk is "" the return value is an empty slice string.
But the functiion PK() consume the first element in PKs() and crash.
Here we return an array with one empty string 