### PR TITLE
check if PKs is empty before access it

### DIFF
--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -165,9 +165,9 @@ func (param Parameters) DeletePK() Parameters {
 
 func (param Parameters) PK() string {
 	pk:=param.PKs()
-  if len(pk) > 0 {
-	   return param.PKs()[0]
-  }
+  	if len(pk) > 0 {
+	   return param.PKs[0]
+ 	}
 return ""
 }
 

--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -164,7 +164,11 @@ func (param Parameters) DeletePK() Parameters {
 }
 
 func (param Parameters) PK() string {
-	return param.PKs()[0]
+	pk:=param.PKs()
+  if len(pk) > 0 {
+	   return param.PKs()[0]
+  }
+return ""
 }
 
 func (param Parameters) IsAll() bool {


### PR DESCRIPTION
param.PKs() can return un empty slice strings.
So to avoid crash we test if the slice is empty before access it