### PR TITLE
Fix: update list of base tables for postgresInsertCheckTableName

### DIFF
--- a/modules/db/connection.go
+++ b/modules/db/connection.go
@@ -130,6 +130,7 @@ var ignoreErrors = [...][]string{
 	{
 		"LastInsertId is not supported",
 		"There is no generated identity value",
+		"LastInsertId is not supported by this driver",
 	},
 	// delete
 	{
@@ -140,6 +141,7 @@ var ignoreErrors = [...][]string{
 		"LastInsertId is not supported",
 		"There is no generated identity value",
 		"no affect",
+		"LastInsertId is not supported by this driver",
 	},
 	// query
 	{
@@ -147,6 +149,7 @@ var ignoreErrors = [...][]string{
 		"There is no generated identity value",
 		"no affect",
 		"out of index",
+		"LastInsertId is not supported by this driver",
 	},
 }
 

--- a/modules/db/statement.go
+++ b/modules/db/statement.go
@@ -544,7 +544,7 @@ func (sql *SQL) Exec() (int64, error) {
 	return res.LastInsertId()
 }
 
-const postgresInsertCheckTableName = "goadmin_menu|goadmin_permissions|goadmin_roles|goadmin_users"
+const postgresInsertCheckTableName = "goadmin_menu|goadmin_permissions|goadmin_roles|goadmin_users|goadmin_user_permissions|goadmin_role_users|goadmin_role_menu|goadmin_role_permissions|goadmin_role_menu"
 
 // Insert exec the insert method of given key/value pairs.
 func (sql *SQL) Insert(values dialect.H) (int64, error) {


### PR DESCRIPTION
Fix: update list of base tables for postgresInsertCheckTableName

Fix: add new error msg to ignoreErrors. Because when using Postgres and calling not supporting method LastInsertedId, it returning: LastInsertId is not supported by this driver.