### PR TITLE
Fix Add Limit

### DIFF
--- a/template/types/display.go
+++ b/template/types/display.go
@@ -147,7 +147,7 @@ func (f FieldDisplay) ToDisplayStringArrayArray(value FieldModel) [][]string {
 func (f FieldDisplay) AddLimit(limit int) DisplayProcessFnChains {
 	return f.DisplayProcessChains.Add(func(value FieldModel) interface{} {
 		if limit > len(value.Value) {
-			return value
+			return value.Value
 		} else if limit < 0 {
 			return ""
 		} else {


### PR DESCRIPTION
Problem: When limit > value it's return FieldModel, and in view rendering FieldModel struct with all properties.
Solution: return value.Value