### PR TITLE
postgres drivername bugfix

### DIFF
--- a/modules/db/postgresql.go
+++ b/modules/db/postgresql.go
@@ -96,7 +96,7 @@ func (db *Postgresql) InitDB(cfgList map[string]config.Database) Connection {
 	db.Once.Do(func() {
 		for conn, cfg := range cfgList {
 
-			sqlDB, err := sql.Open("postgres", cfg.GetDSN())
+			sqlDB, err := sql.Open(cfg.Driver, cfg.GetDSN())
 			if err != nil {
 				if sqlDB != nil {
 					_ = sqlDB.Close()


### PR DESCRIPTION
Can't start admin with hardcoded driver name

```
❯ go run ./cmd/adm/main.go
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

GoAdmin is now running.
Running in "debug" mode. Switch to "release" mode in production.

2021-07-07T19:49:18.212+0500    INFO    engine/engine.go:402    =====> Initialize database connections
panic: sql: unknown driver "postgres" (forgotten import?)

goroutine 1 [running]:
github.com/GoAdminGroup/go-admin/modules/db.(*Postgresql).InitDB.func1()
        /Users/stepan/go/pkg/mod/github.com/!go!admin!group/go-admin@v1.2.23/modules/db/postgresql.go:104 +0x31e
sync.(*Once).doSlow(0xc0003f18c8, 0xc00031f8f8)
        /usr/local/Cellar/go/1.15.7/libexec/src/sync/once.go:66 +0xec
sync.(*Once).Do(...)
        /usr/local/Cellar/go/1.15.7/libexec/src/sync/once.go:57
github.com/GoAdminGroup/go-admin/modules/db.(*Postgresql).InitDB(0xc0003f18c0, 0xc0004b8ff0, 0xc00031f9b8, 0x0)
        /Users/stepan/go/pkg/mod/github.com/!go!admin!group/go-admin@v1.2.23/modules/db/postgresql.go:96 +0x9a
github.com/GoAdminGroup/go-admin/engine.(*Engine).initDatabase(0xc0003e27d0, 0xc0003e27d0)
        /Users/stepan/go/pkg/mod/github.com/!go!admin!group/go-admin@v1.2.23/engine/engine.go:181 +0x1c3
github.com/GoAdminGroup/go-admin/engine.(*Engine).AddConfig(0xc0003e27d0, 0xc0004be000, 0xc00031fac0)
        /Users/stepan/go/pkg/mod/github.com/!go!admin!group/go-admin@v1.2.23/engine/engine.go:141 +0x53
main.main()
        /Users/stepan/projects/talent-notifications/cmd/adm/main.go:48 +0x22b
exit status 2

```