### PR TITLE
modify the graceful shutdown of gin

### DIFF
--- a/adm/project_template.go
+++ b/adm/project_template.go
@@ -5,10 +5,15 @@ var projectTemplate = map[string]string{
 package main
 
 import (
+	"context"
+	"errors"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
+	"time"
 
 	_ "github.com/GoAdminGroup/go-admin/adapter/gin"                    // web framework adapter
 	_ "github.com/GoAdminGroup/go-admin/modules/db/drivers/{{.DriverModule}}" // sql driver
@@ -53,13 +58,32 @@ func startServer() {
 
 	{{if ne .Orm ""}}models.Init(eng.{{title .Driver}}Connection()){{end}}
 
-	_ = r.Run(":{{.Port}}")
+	srv := &http.Server{
+		Addr:    ":{{.Port}}",
+		Handler: r,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && errors.Is(err, http.ErrServerClosed) {
+			log.Printf("listen: %s\n", err)
+		}
+	}()
 
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
+	log.Println("Shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatal("Server forced to shutdown:", err)
+	}
 	log.Print("closing database connection")
 	eng.{{title .Driver}}Connection().Close()
+
+	log.Println("Server exiting")
 }
 {{end}}`,
 


### PR DESCRIPTION
I found some problem with the shutdown of gin server,  look at the following template code which is the current code:
```
_ = r.Run(":{{.Port}}")
quit := make(chan os.Signal, 1)
signal.Notify(quit, os.Interrupt)
<-quit
log.Print("closing database connection")
eng.{{title .Driver}}Connection().Close()
```

the `r.RUN()` function call will block the main goroutine forever in `Accept()` syscall.

and the quit Signal will never be caught.