### PR TITLE
Updated endNum on last page

### DIFF
--- a/plugins/admin/modules/paginator/paginator.go
+++ b/plugins/admin/modules/paginator/paginator.go
@@ -127,6 +127,10 @@ func Get(cfg Config) types.PaginatorAttribute {
 		endNum = paginator.Total
 	}
 
+	if cfg.Param.PageInt >= (cfg.Size+cfg.Param.PageSizeInt-1)/cfg.Param.PageSizeInt {
+		endNum = paginator.Total
+	}
+
 	paginator.SetEntriesInfo(template.HTML(fmt.Sprintf(language.Get("showing <b>%s</b> to <b>%s</b> of <b>%s</b> entries"),
 		paginator.CurPageStartIndex, endNum, paginator.Total)))
 


### PR DESCRIPTION
The paginator not correctly shows the number of entries on the last page. For example: ```showing 621 to 640 of 636 entries```