### PR TITLE
fix: pg table 存在 shcema 时，sql无法正确执行

### DIFF
--- a/modules/db/dialect/postgresql.go
+++ b/modules/db/dialect/postgresql.go
@@ -22,7 +22,7 @@ func (postgresql) ShowTables() string {
 }
 
 func (postgresql) ShowColumns(table string) string {
-	tableArr := strings.Split(table, ".")
+	tableArr := strings.Split(table, "\".\"")
 	if len(tableArr) > 1 {
 		return fmt.Sprintf("select * from information_schema.columns where table_name = '%s' and table_schema = '%s'", tableArr[1], tableArr[0])
 	} else {

--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -175,16 +175,24 @@ func (param Parameters) IsAll() bool {
 	return param.GetFieldValue(IsAll) == True
 }
 
-func (param Parameters) WithURLPath(path string) Parameters {
+func (param *Parameters) WithURLPath(path string) Parameters {
 	param.URLPath = path
-	return param
+	return *param
+}
+
+func (param *Parameters) isAllTrue() {
+	param.Fields[IsAll] = []string{True}
+}
+
+func (param *Parameters) isAllFalse() {
+	param.Fields[IsAll] = []string{False}
 }
 
 func (param Parameters) WithIsAll(isAll bool) Parameters {
 	if isAll {
-		param.Fields[IsAll] = []string{True}
+		param.isAllTrue()
 	} else {
-		param.Fields[IsAll] = []string{False}
+		param.isAllFalse()
 	}
 	return param
 }
@@ -254,16 +262,16 @@ func (param Parameters) Join() string {
 	return p.Encode()
 }
 
-func (param Parameters) SetPage(page string) Parameters {
+func (param *Parameters) SetPage(page string) Parameters {
 	param.Page = page
 	param.PageInt, _ = strconv.Atoi(page)
-	return param
+	return *param
 }
 
-func (param Parameters) SetPageSize(pageSize string) Parameters {
+func (param *Parameters) SetPageSize(pageSize string) Parameters {
 	param.PageSize = pageSize
 	param.PageSizeInt, _ = strconv.Atoi(pageSize)
-	return param
+	return *param
 }
 
 func (param Parameters) GetRouteParamStr() string {

--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -425,9 +425,9 @@ func (param Parameters) Statement(wheres, table, delimiter, delimiter2 string, w
 					for range value {
 						qmark += "?,"
 					}
-					wheres += table + "." + modules.FilterField(key, delimiter, delimiter2) + " " + op + " (" + qmark[:len(qmark)-1] + ") and "
+					wheres += modules.Delimiter(delimiter, delimiter2, table) + "." + modules.FilterField(key, delimiter, delimiter2) + " " + op + " (" + qmark[:len(qmark)-1] + ") and "
 				} else {
-					wheres += table + "." + modules.FilterField(key, delimiter, delimiter2) + " " + op + " ? and "
+					wheres += modules.Delimiter(delimiter, delimiter2, table) + "." + modules.FilterField(key, delimiter, delimiter2) + " " + op + " ? and "
 				}
 				if op == "like" && !strings.Contains(value[0], "%") {
 					whereArgs = append(whereArgs, "%"+filterProcess(key, value[0], keyIndexSuffix)+"%")


### PR DESCRIPTION
比如 pg 的 schema 为 “schema01”， 拼成的 query sql 的表名为 "schema.tableName"，但是 pg 需要 "schema"."tableName"。所以在 SetTable() 接口中传入 "schema"."tableName"。