### PR TITLE
Fix string primary key deleteJs on details page

### DIFF
--- a/plugins/admin/controller/api_detail.go
+++ b/plugins/admin/controller/api_detail.go
@@ -98,7 +98,7 @@ function DeletePost(id) {
 }
 
 $('.delete-btn').on('click', function (event) {
-	DeletePost(%s)
+	DeletePost('%s')
 });
 
 </script>`, language.Get("are you sure to delete"), language.Get("yes"), language.Get("cancel"), deleteUrl, infoUrl, id)

--- a/plugins/admin/controller/detail.go
+++ b/plugins/admin/controller/detail.go
@@ -107,7 +107,7 @@ function DeletePost(id) {
 }
 
 $('.delete-btn').on('click', function (event) {
-	DeletePost(%s)
+	DeletePost('%s')
 });
 
 </script>`, language.Get("are you sure to delete"), language.Get("yes"),


### PR DESCRIPTION
Non-integer primary key causes errors in deleteJs on details page (including api)

<img width="491" alt="Screenshot 2022-05-28 at 14 13 44" src="https://user-images.githubusercontent.com/9019326/170823070-13807a23-b309-471f-bd90-779d7b5f9ceb.png">
<img width="400" alt="Screenshot 2022-05-28 at 14 14 07" src="https://user-images.githubusercontent.com/9019326/170823081-ae72114b-9e7c-49af-a5e8-fbf88d7a5a57.png">

Adding quotes works for both integer and string pk-s
