### PR TITLE
Add `ILIKE` operator to filter types for filtered result becomes case-insensitive.

### DIFF
--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -54,14 +54,15 @@ const (
 )
 
 var operators = map[string]string{
-	"like": "like",
-	"gr":   ">",
-	"gq":   ">=",
-	"eq":   "=",
-	"ne":   "!=",
-	"le":   "<",
-	"lq":   "<=",
-	"free": "free",
+	"ilike": "ilike",
+	"like":  "like",
+	"gr":    ">",
+	"gq":    ">=",
+	"eq":    "=",
+	"ne":    "!=",
+	"le":    "<",
+	"lq":    "<=",
+	"free":  "free",
 }
 
 var keys = []string{Page, PageSize, Sort, Columns, Prefix, Pjax, form.NoAnimationKey}
@@ -419,7 +420,7 @@ func (param Parameters) Statement(wheres, table, delimiter, delimiter2 string, w
 			} else {
 				wheres += keys[0] + "." + modules.FilterField(keys[1], delimiter, delimiter2) + " " + op + " ? and "
 			}
-			if op == "like" && !strings.Contains(val, "%") {
+			if strings.Contains(op, "like") && !strings.Contains(val, "%") {
 				whereArgs = append(whereArgs, "%"+val+"%")
 			} else {
 				for _, v := range value {
@@ -437,7 +438,7 @@ func (param Parameters) Statement(wheres, table, delimiter, delimiter2 string, w
 				} else {
 					wheres += modules.Delimiter(delimiter, delimiter2, table) + "." + modules.FilterField(key, delimiter, delimiter2) + " " + op + " ? and "
 				}
-				if op == "like" && !strings.Contains(value[0], "%") {
+				if strings.Contains(op, "like") && !strings.Contains(value[0], "%") {
 					whereArgs = append(whereArgs, "%"+filterProcess(key, value[0], keyIndexSuffix)+"%")
 				} else {
 					for _, v := range value {

--- a/template/types/operators.go
+++ b/template/types/operators.go
@@ -5,6 +5,7 @@ import "html/template"
 type FilterOperator string
 
 const (
+	FilterOperatorILike          FilterOperator = "ilike"
 	FilterOperatorLike           FilterOperator = "like"
 	FilterOperatorGreater        FilterOperator = ">"
 	FilterOperatorGreaterOrEqual FilterOperator = ">="
@@ -17,6 +18,8 @@ const (
 
 func GetOperatorFromValue(value string) FilterOperator {
 	switch value {
+	case "ilike":
+		return FilterOperatorILike
 	case "like":
 		return FilterOperatorLike
 	case "gr":
@@ -40,6 +43,8 @@ func GetOperatorFromValue(value string) FilterOperator {
 
 func (o FilterOperator) Value() string {
 	switch o {
+	case FilterOperatorILike:
+		return "ilike"
 	case FilterOperatorLike:
 		return "like"
 	case FilterOperatorGreater:
@@ -66,7 +71,7 @@ func (o FilterOperator) String() string {
 }
 
 func (o FilterOperator) Label() template.HTML {
-	if o == FilterOperatorLike {
+	if o == FilterOperatorLike || o == FilterOperatorILike {
 		return ""
 	}
 	return template.HTML(o)
@@ -78,7 +83,7 @@ func (o FilterOperator) AddOrNot() bool {
 
 func (o FilterOperator) Valid() bool {
 	switch o {
-	case FilterOperatorLike, FilterOperatorGreater, FilterOperatorGreaterOrEqual,
+	case FilterOperatorILike, FilterOperatorLike, FilterOperatorGreater, FilterOperatorGreaterOrEqual,
 		FilterOperatorLess, FilterOperatorLessOrEqual, FilterOperatorFree:
 		return true
 	default:


### PR DESCRIPTION
Add **_ILIKE_** to **_FilterOperator_** for supporting case-insensitive search.
Solves this [issue](https://github.com/GoAdminGroup/go-admin/issues/541).