### PR TITLE
feat: Change the default image address of dead plugin

### DIFF
--- a/plugins/admin/controller/plugins.go
+++ b/plugins/admin/controller/plugins.go
@@ -299,7 +299,7 @@ func (h *Handler) pluginStoreBox(param PluginBoxParam) template.HTML {
 func (h *Handler) pluginBox(param PluginBoxParam) template.HTML {
 	cover := template2.HTML(param.Info.MiniCover)
 	if cover == template2.HTML("") {
-		cover = "/admin/assets/dist/img/plugin_default.png"
+		cover = template.HTML(config.Url("/assets/dist/img/plugin_default.png"))
 	}
 
 	jump := param.IndexURL


### PR DESCRIPTION
The plugin image starts with admin and cannot be customized based on the prefix