### PR TITLE
FIX sql 1.7.1 bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/GoAdminGroup/html v0.0.1
 	github.com/NebulousLabs/fastrand v0.0.0-20181203155948-6fb6489aac4e
 	github.com/denisenkom/go-mssqldb v0.0.0-20200206145737-bbfc9a55622e
-	github.com/go-sql-driver/mysql v1.5.0
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jawher/mow.cli v1.2.0 // indirect
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZp
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/plugins/admin/models/user.go
+++ b/plugins/admin/models/user.go
@@ -341,15 +341,19 @@ func (t UserModel) WithMenus() UserModel {
 	var menuIds []int64
 
 	for _, mid := range menuIdsModel {
-		if parentId, ok := mid["parent_id"].(int64); ok && parentId != 0 {
+		if parentId, err := strconv.Atoi(string(mid["parent_id"].([]uint8))); err == nil && parentId != 0 {
 			for _, mid2 := range menuIdsModel {
-				if mid2["menu_id"].(int64) == mid["parent_id"].(int64) {
-					menuIds = append(menuIds, mid["menu_id"].(int64))
+				mid2Int, _ := strconv.Atoi(string(mid2["menu_id"].([]uint8)))
+				midInt, _ := strconv.Atoi(string(mid["parent_id"].([]uint8)))
+				if mid2Int == midInt {
+					mInt, _ := strconv.Atoi(string(mid["menu_id"].([]uint8)))
+					menuIds = append(menuIds, int64(mInt))
 					break
 				}
 			}
 		} else {
-			menuIds = append(menuIds, mid["menu_id"].(int64))
+			mInt, _ := strconv.Atoi(string(mid["menu_id"].([]uint8)))
+			menuIds = append(menuIds, int64(mInt))
 		}
 	}
 


### PR DESCRIPTION
go-sql-driver 1.7.1 新版本返回菜单id数据为[]uint8，将其转换为int解决问题