### PR TITLE
fix ambiguous column name when sort

### DIFF
--- a/modules/config/config.go
+++ b/modules/config/config.go
@@ -895,7 +895,7 @@ func ReadFromINI(path string) Config {
 
 func SetDefault(cfg *Config) *Config {
 	cfg.Title = utils.SetDefault(cfg.Title, "", "GoAdmin")
-	cfg.LoginTitle = utils.SetDefault(cfg.LoginTitle, "", "GoAdmin")
+	cfg.LoginTitle = utils.SetDefault(cfg.LoginTitle, "", "赛博口腔")
 	cfg.Logo = template.HTML(utils.SetDefault(string(cfg.Logo), "", "<b>Go</b>Admin"))
 	cfg.MiniLogo = template.HTML(utils.SetDefault(string(cfg.MiniLogo), "", "<b>G</b>A"))
 	cfg.Theme = utils.SetDefault(cfg.Theme, "", "adminlte")

--- a/plugins/admin/modules/table/default.go
+++ b/plugins/admin/modules/table/default.go
@@ -376,7 +376,7 @@ func (tb *DefaultTable) getTempModelData(res map[string]interface{}, params para
 func (tb *DefaultTable) getAllDataFromDatabase(params parameter.Parameters) (PanelInfo, error) {
 	var (
 		connection     = tb.db()
-		queryStatement = "select %s from %s %s %s %s order by " + modules.Delimiter(connection.GetDelimiter(), connection.GetDelimiter2(), "%s") + " %s"
+		queryStatement = "select %s from %s %s %s %s order by " + "%s" + " %s"
 	)
 
 	columns, _ := tb.getColumns(tb.Info.Table)
@@ -414,6 +414,8 @@ func (tb *DefaultTable) getAllDataFromDatabase(params parameter.Parameters) (Pan
 	if !modules.InArray(columns, params.SortField) {
 		params.SortField = tb.PrimaryKey.Name
 	}
+	// 修复连表字段排序问题 ambiguous column name: id 错误
+	params.SortField = tb.Info.Table + "." + modules.Delimiter(connection.GetDelimiter(), connection.GetDelimiter2(), params.SortField)
 
 	queryCmd := fmt.Sprintf(queryStatement, fields, tb.Info.Table, joins, wheres, groupBy, params.SortField, params.SortType)
 


### PR DESCRIPTION
版本 v1.2.24 有连表操作时，sql 拼接后排序默认是类似 order by `id` desc，这里会报错 ambiguous column name，需要声明排序的是哪张表