### PR TITLE
fix: 修复FilterOperatorLike导致页面显示不必要form-group的问题

### DIFF
--- a/template/types/operators.go
+++ b/template/types/operators.go
@@ -73,7 +73,7 @@ func (o FilterOperator) Label() template.HTML {
 }
 
 func (o FilterOperator) AddOrNot() bool {
-	return string(o) != "" && o != FilterOperatorFree
+	return string(o) != "" && o != FilterOperatorFree && o != FilterOperatorLike
 }
 
 func (o FilterOperator) Valid() bool {

--- a/template/types/operators_test.go
+++ b/template/types/operators_test.go
@@ -1,0 +1,86 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestFilterOperatorAddOrNot(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator FilterOperator
+		expected bool
+	}{
+		{
+			name:     "FilterOperatorLike should not add operator field",
+			operator: FilterOperatorLike,
+			expected: false,
+		},
+		{
+			name:     "FilterOperatorFree should not add operator field",
+			operator: FilterOperatorFree,
+			expected: false,
+		},
+		{
+			name:     "Empty operator should not add operator field",
+			operator: FilterOperator(""),
+			expected: false,
+		},
+		{
+			name:     "FilterOperatorGreater should add operator field",
+			operator: FilterOperatorGreater,
+			expected: true,
+		},
+		{
+			name:     "FilterOperatorEqual should add operator field",
+			operator: FilterOperatorEqual,
+			expected: true,
+		},
+		{
+			name:     "FilterOperatorNotEqual should add operator field",
+			operator: FilterOperatorNotEqual,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.operator.AddOrNot()
+			if result != tt.expected {
+				t.Errorf("FilterOperator.AddOrNot() = %v, expected %v for operator %s", result, tt.expected, string(tt.operator))
+			}
+		})
+	}
+}
+
+func TestFilterOperatorLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		operator FilterOperator
+		expected string
+	}{
+		{
+			name:     "FilterOperatorLike should return empty label",
+			operator: FilterOperatorLike,
+			expected: "",
+		},
+		{
+			name:     "FilterOperatorGreater should return > label",
+			operator: FilterOperatorGreater,
+			expected: ">",
+		},
+		{
+			name:     "FilterOperatorEqual should return = label",
+			operator: FilterOperatorEqual,
+			expected: "=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := string(tt.operator.Label())
+			if result != tt.expected {
+				t.Errorf("FilterOperator.Label() = %v, expected %v for operator %s", result, tt.expected, string(tt.operator))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- 修改AddOrNot()方法，让Like操作符不添加额外的操作符字段
- 添加相应的单元测试验证修复效果
- 解决了使用Like过滤器时页面出现多余表单元素的问题

在使用 FieldFilterable(types.FilterType{Operator: types.FilterOperatorLike}) 时， 之前会错误地创建隐藏的操作符字段，导致页面显示不应该出现的form-group。
现在Like操作符被视为隐式操作，不再创建额外的UI元素。
<img width="774" alt="image" src="https://github.com/user-attachments/assets/b45db448-af53-4232-a3e0-67439d38ec0e" />
