### PR TITLE
Fix the UI display problem of FilterOperatorLike while maintaining the function of correctly generating Like sql statements

### DIFF
--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -64,6 +64,19 @@ var operators = map[string]string{
 	"free": "free",
 }
 
+// Global registry for Like operator fields
+var likeOperatorFields = make(map[string]bool)
+
+// RegisterLikeOperatorField registers a field as using the Like operator
+func RegisterLikeOperatorField(fieldName string) {
+	likeOperatorFields[fieldName] = true
+}
+
+// IsLikeOperatorField checks if a field is registered as using the Like operator
+func IsLikeOperatorField(fieldName string) bool {
+	return likeOperatorFields[fieldName]
+}
+
 var keys = []string{Page, PageSize, Sort, Columns, Prefix, Pjax, form.NoAnimationKey}
 
 func BaseParam() Parameters {
@@ -402,7 +415,11 @@ func (param Parameters) Statement(wheres, table, delimiter, delimiter2 string, w
 		} else if len(value) > 1 {
 			op = "in"
 		} else if !strings.Contains(key, FilterParamOperatorSuffix) {
-			op = operators[param.GetFieldOperator(key, keyIndexSuffix)]
+			if IsLikeOperatorField(key) {
+				op = "like"
+			} else {
+				op = operators[param.GetFieldOperator(key, keyIndexSuffix)]
+			}
 		} else {
 			continue
 		}

--- a/template/types/info.go
+++ b/template/types/info.go
@@ -200,6 +200,11 @@ func (f Field) GetFilterFormFields(params parameter.Parameters, headField string
 			keySuffix = parameter.FilterParamCountInfix + strconv.Itoa(index)
 		}
 
+		// Register Like operator fields for global tracking
+		if filter.Operator == FilterOperatorLike {
+			parameter.RegisterLikeOperatorField(headField)
+		}
+
 		if filter.Type.IsRange() {
 			value = params.GetFilterFieldValueStart(headField)
 			value2 = params.GetFilterFieldValueEnd(headField)


### PR DESCRIPTION
- UI level: Like operator no longer displays additional operator selection fields
- Backend level: Like operator can correctly generate SQL queries (LIKE '%value%')
<img width="830" alt="image" src="https://github.com/user-attachments/assets/f0379b92-04ff-403f-8fdd-013209f7e7f0" />
