### PR TITLE
fix: Use MySQL information.schema columns table with ORDINAL_POSITION as order to get same order of the create table sql

### DIFF
--- a/modules/db/dialect/mysql.go
+++ b/modules/db/dialect/mysql.go
@@ -19,7 +19,8 @@ func (mysql) ShowColumnsWithComment(schema, table string) string {
 		WHERE 
 			table_name = '` + table + `'
 		AND
-			table_schema = '` + schema + `'`
+			table_schema = '` + schema + `'` +
+        `ORDER BY ORDINAL_POSITION`
 }
 
 func (mysql) ShowColumns(table string) string {


### PR DESCRIPTION
If we do not use this order, we can get the columns in a unexpected order.
So I think we can add this.
