### PR TITLE
update: support multi tabs in one page

### DIFF
--- a/template/components/tabs.go
+++ b/template/components/tabs.go
@@ -4,10 +4,12 @@ import (
 	"html/template"
 
 	"github.com/GoAdminGroup/go-admin/template/types"
+	"github.com/google/uuid"
 )
 
 type TabsAttribute struct {
 	Name string
+	Id   string
 	Data []map[string]template.HTML
 	types.Attribute
 }
@@ -18,5 +20,8 @@ func (compo *TabsAttribute) SetData(value []map[string]template.HTML) types.Tabs
 }
 
 func (compo *TabsAttribute) GetContent() template.HTML {
+	if compo.Id == "" {
+		compo.Id = uuid.New().String()[:8]
+	}
 	return ComposeHtml(compo.TemplateList, compo.Separation, *compo, "tabs")
 }


### PR DESCRIPTION
tabs 模板使用 `range` 循环索引 `$key`（0, 1, 2...）作为 tab 的 id（`#tab_0`, `#tab_1`）。每次调用 `Tabs()` 都会重新从 0 开始计数，因此同一页面上的多个 Tabs 组件会生&#x6210;__&#x76F8;同的 id__，导致 Bootstrap 的 `data-toggle="tab"` 锚点冲突，点击 tab 时会错误地激活另一个 Tabs 组件的面板。
